### PR TITLE
Fix launch instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 clone the repo
 
+```shell script
 npm i
 
-electron .
+npm run s
+```
 
 # How to package/distribute the repo
 
+```shell script
 npm run dist
-
-
+```


### PR DESCRIPTION
Electron can normally not be executed directly from the shell, therefor use the `npm` script instead