### PR TITLE
Retrieve music-metadata via main process.

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,6 @@
-const { app, BrowserWindow } = require('electron') 
+const { app, BrowserWindow, ipcMain } = require('electron')
+const musicMetadata = require('music-metadata');
+
 const template = [
   { role: 'zoomin', accelerator: 'CommandOrControl+=' },
     ]
@@ -51,7 +53,14 @@ app.on('activate', () => {
   if (BrowserWindow.getAllWindows().length === 0) { 
     createWindow() 
   } 
-}) 
+})
+
+ipcMain.handle('get-audio-metadata', async (event, filename) => {
+  console.log(`Loading metadata from ${filename}...`);
+  const metadata = await musicMetadata.parseFile(filename, {duration: true});
+  console.log(`Music-metadata: track-number = ${metadata.common.track.no}, duration = ${metadata.format.duration} sec.`);
+  return metadata;
+});
   
 // In this file, you can include the rest of your  
 // app's specific main process code. You can also  

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+const { ipcRenderer } = window.require('electron');
+
 var newUploadFiles = {}
 
 //display every upload in uploadList[]
@@ -1089,23 +1091,20 @@ async function newUploadFileDropEvent(event, preventDefault) {
             //console.log('newUploadFileDropEvent() audioFormat = ', audioFormat)
 
             //get metadata
-            let trackNumRet = await getTrackNum(f.path)
-            //console.log('newUploadFileDropEvent() trackNum = ', trackNumRet)
+            const metadata = await getMetadata(f.path)
 
-            //get audiolength
-            //console.log('newUploadFileDropEvent() get audioLength ')
             let audioLength = 0
             try {
                 audioLength = await getDuration(f.path)
                 //console.log('newUploadFileDropEvent() audioLength1 = ', audioLength)
-                audioLength = new Date(audioLength * 1000).toISOString().substr(11, 8)
+                audioLength = new Date(metadata.format.duration * 1000).toISOString().substr(11, 8)
             } catch (err) {
                 //console.log('err getting audio length: ', err)
             }
             //console.log('newUploadFileDropEvent() audioLength = ', audioLength)
 
             //push results
-            fileList.audio.push({ 'path': f.path, 'type': audioFormat, 'name': f.name, 'length': audioLength, 'trackNum': trackNumRet })
+            fileList.audio.push({ 'path': f.path, 'type': audioFormat, 'name': f.name, 'length': audioLength, 'trackNum': metadata.common.track.no })
         }
     }
     newUploadFiles = fileList
@@ -1155,50 +1154,12 @@ function sum(date1, date2) {
 }
 
 //get duration of audio file
-const mm = require('music-metadata');
-const util = require('util');
 
-function getDuration(src) {
-    return new Promise(function (resolve) {
-        mm.parseFile(src)
-            .then(metadata => {
-                resolve(metadata.format.duration)
-            })
-            .catch(err => {
-                console.error('err = ', err.message);
-            });
-    });
+async function getMetadata(src) {
+    const metadata = await ipcRenderer.invoke('get-audio-metadata', src);
+    console.log(`Music-metadata: track-number = ${metadata.common.track.no}, duration = ${metadata.format.duration} sec.`);
+    return metadata;
 }
-
-//get track num from audio file metadata
-function getTrackNum(src) {
-    //console.log("getTrackNum() src = ", src)
-    return new Promise(function (resolve) {
-
-        //console.log('getTrackNum() init requirerments called')
-        try {
-            //console.log('getTrackNum() mm = ', mm)
-            mm.parseFile(src)
-                .then(metadata => {
-                    //console.log('getTrackNum() TRACK NUMBER = ', metadata.common.track.no)
-                    resolve(metadata.common.track.no)
-                })
-                .catch(err => {
-                    //console.error('getTrackNum() err = ', err.message);
-                    resolve(null)
-                });
-
-        } catch (err) {
-            //console.log('getTrackNum() err caught = ', err)
-        }
-
-        //console.log('getTrackNum() end')
-        //resolve(null)
-
-    });
-}
-
-
 
 //datatables natural sort plugin code below:
 (function () {


### PR DESCRIPTION
Retrieve metadata via main process.

Changes / fixes / improvements:
1. Retrieve metadata via main process.
1. Remove unnecessary wrapping of promises.
1. Fix catch handling the promise resolver as well.
1. Retrieve metadata at once instead re-parsing it for duration / track-number

Alternative to: MartinBarker/audio-archiver#17, related to Borewit/music-metadata#718